### PR TITLE
Atualizar valores de dimensões para compatibilidade com Mini Envios

### DIFF
--- a/frenet/frenet.php
+++ b/frenet/frenet.php
@@ -40,10 +40,10 @@ class Frenet extends CarrierModule
 
     private $debug='no';
 
-    private $minimum_height=2;
-    private $minimum_width=11;
-    private $minimum_length=16;
-    private $minimum_weight=1;
+    private $minimum_height=1;
+    private $minimum_width=10;
+    private $minimum_length=15;
+    private $minimum_weight=0.001;
 
     private $prazoEntrega = array();
 


### PR DESCRIPTION
Este PR atualiza os valores default de dimensão do produto, permitindo a funcionalidade correta do Mini Envios dos Correios.

Segui os valores especificados nesta documentação https://ajuda.frenet.com.br/s/article/como-funciona-o-mini-envios-dos-correios